### PR TITLE
Event Loop Timer: don't call expiration callback if timer is schedule…

### DIFF
--- a/lib/furi/core/event_loop_timer.c
+++ b/lib/furi/core/event_loop_timer.c
@@ -131,6 +131,11 @@ bool furi_event_loop_process_expired_timers(FuriEventLoop* instance) {
         return false;
     }
 
+    if(timer->request == FuriEventLoopTimerRequestStop) {
+        // Timer scheduled for stoppage, skip it
+        return false;
+    }
+
     TimerList_unlink(timer);
 
     if(timer->periodic) {


### PR DESCRIPTION
Timer won't call expiration callback after call to `furi_event_loop_timer_stop`.