### PR TITLE
[FW-846] Port microsecond delay to furi_hal_cpu

### DIFF
--- a/lib/furi/core/kernel.c
+++ b/lib/furi/core/kernel.c
@@ -202,5 +202,12 @@ void furi_delay_ms(uint32_t milliseconds) {
 }
 
 void furi_delay_us(uint32_t microseconds) {
-    furi_hal_cortex_delay_us(microseconds);
+    furi_check(microseconds < (UINT32_MAX / furi_hal_cpu_get_cycles_per_us()));
+
+    const uint32_t cycles_start = furi_hal_cpu_get_cycle_count();
+    const uint32_t cycles_to_wait = furi_hal_cpu_get_cycles_per_us() * microseconds;
+
+    while((furi_hal_cpu_get_cycle_count() - cycles_start) < cycles_to_wait) {
+        // Nothing
+    }
 }


### PR DESCRIPTION
# What's new

- Port `furi_delay_us` to `furi_hal_cpu`