### PR TITLE
thread: make furi_thread_catch a naked trampoline so task unwinds terminate cleanly

### DIFF
--- a/lib/furi/core/thread.c
+++ b/lib/furi/core/thread.c
@@ -85,13 +85,23 @@ static FuriMessageQueue* furi_thread_scrub_message_queue = NULL;
 static size_t __furi_thread_stdout_write(FuriThread* thread, const char* data, size_t size);
 static int32_t __furi_thread_stdout_flush(FuriThread* thread);
 
-/** Catch threads that are trying to exit wrong way */
-__attribute__((__noreturn__)) void furi_thread_catch(void) { //-V1082
+/** Catch threads that are trying to exit wrong way - crash implementation */
+static __attribute__((used, __noreturn__)) void furi_thread_catch_impl(void) {
     // If you're here it means you're probably doing something wrong
     // with critical sections or with scheduler state
-    asm volatile("nop"); // extra magic
     furi_crash("You are doing it wrong"); //-V779
     __builtin_unreachable();
+}
+
+/** Artificial return target for FreeRTOS tasks (configTASK_RETURN_ADDRESS).
+ *
+ * Naked so there is no prologue, and .cfi_undefined lr tells the DWARF
+ * unwinder that the return address is not recoverable here. Without this,
+ * the unwinder tries to restore LR from below the freshly initialised task
+ * stack and walks off into garbage (see flipperone-mcu-firmware issue #51). */
+__attribute__((naked, __noreturn__)) void furi_thread_catch(void) { //-V1082
+    asm volatile(".cfi_undefined lr\n\t"
+                 "b furi_thread_catch_impl\n\t");
 }
 
 static void furi_thread_set_state(FuriThread* thread, FuriThreadState state) {


### PR DESCRIPTION
Part of the fix for the garbage FreeRTOS call stacks reported in flipperdevices/flipperone-mcu-firmware#51.

`furi_thread_catch` is the artificial return address every task "returns" into (`configTASK_RETURN_ADDRESS`). As an ordinary function it compiles to `push {r3, lr}; ...`, and its DWARF FDE describes a frame with a saved return address — so when the debugger unwinds a task down to this boundary it reads a junk word off the pristine task stack and prints a bogus bottom frame. The firmware works around it today with a `(furi_thread_catch + 2)` prologue-skip in `configTASK_RETURN_ADDRESS`, but the FDE row at `+2` still says `CFA=r13+8, ra=[CFA-4]`, so the junk frame survives.

This makes `furi_thread_catch` a `naked` trampoline (`b furi_thread_catch_impl`) annotated with `.cfi_undefined lr`. The crash body moves to a `static __attribute__((used))` `furi_thread_catch_impl`. With `ra` marked undefined, the unwinder terminates cleanly at the thread boundary instead of inventing a caller.

Verified on the built firmware (arm-none-eabi-gcc 14.2.1, pico-sdk 2.2.0):

- before: `readelf --debug-dump=frames-interp` at `furi_thread_catch+2` → `CFA r13+8, ra c-4`
- after: the FDE shows `ra: u` (undefined), and `objdump -d` shows `furi_thread_catch: b.w furi_thread_catch_impl` with no prologue.

Firmware builds clean (`[264/264]`, uf2 produced). The companion `FreeRTOSConfig.h` change (drop the `+ 2`) is a separate PR against `flipperone-mcu-firmware` and should land after this one, since dropping the skip while the symbol is still a normal function would read the real prologue.

No functional change to the crash handler itself — it still logs and reboots; only its unwind metadata changes.

The per-task frame parsing (the larger half of #51) is fixed separately by raspberrypi/openocd#151, which teaches OpenOCD the ARMv8-M (`RP2350_ARM_NTZ`) stack layout.