### PR TITLE
[FW-973] More verbose free_blocks

### DIFF
--- a/lib/furi/core/memmgr_heap.c
+++ b/lib/furi/core/memmgr_heap.c
@@ -248,7 +248,7 @@ void memmgr_heap_printf_free_blocks(void) {
 
     vTaskSuspendAll();
 
-    size_t blocks_info_sz = 0;
+    size_t blocks_info_sz = 1;
     pxBlock = xStart.pxNextFreeBlock;
     while(pxBlock->pxNextFreeBlock != NULL) {
         pxBlock = pxBlock->pxNextFreeBlock;
@@ -258,7 +258,7 @@ void memmgr_heap_printf_free_blocks(void) {
 
     blocks_info = pvPortMalloc(blocks_info_sz * sizeof(MemmgrHeapBlockInfo));
     size_t blocks_count = 0;
-    pxBlock = xStart.pxNextFreeBlock;
+    pxBlock = &xStart;
     while((pxBlock->pxNextFreeBlock != NULL) && (blocks_count < blocks_info_sz)) {
         blocks_info[blocks_count].addr = (size_t)pxBlock;
         blocks_info[blocks_count].size = (size_t)pxBlock->xBlockSize;
@@ -268,9 +268,29 @@ void memmgr_heap_printf_free_blocks(void) {
 
     xTaskResumeAll();
 
+    size_t total_free = 0;
+    size_t max_free = 0;
     for(size_t i = 0; i < blocks_count; i++) {
-        printf("A %p S %lu\r\n", (void*)blocks_info[i].addr, (uint32_t)blocks_info[i].size);
+        size_t used_size = 0;
+        if(i < blocks_count - 1) {
+            used_size = blocks_info[i + 1].addr - (blocks_info[i].addr + blocks_info[i].size);
+        }
+        printf(
+            "0x%p\tFree: %lu \tUsed: %lu\r\n",
+            (void*)blocks_info[i].addr,
+            (uint32_t)blocks_info[i].size,
+            (uint32_t)used_size);
+
+        total_free += blocks_info[i].size;
+        if(blocks_info[i].size > max_free) {
+            max_free = blocks_info[i].size;
+        }
     }
+    uint32_t fragmentation = total_free > 0 ? (100 - (max_free * 100 / total_free)) : 0;
+    printf(
+        "\r\nLargest free block: %lu\r\nFragmentation: %lu%%\r\n",
+        (uint32_t)max_free,
+        fragmentation);
     vPortFree(blocks_info);
 }
 

--- a/lib/furi/core/memmgr_heap.c
+++ b/lib/furi/core/memmgr_heap.c
@@ -237,14 +237,9 @@ size_t memmgr_heap_get_max_free_block(void) {
     return max_free_size;
 }
 
-typedef struct {
-    size_t addr;
-    size_t size;
-} MemmgrHeapBlockInfo;
-
-void memmgr_heap_printf_free_blocks(void) {
+MemmgrHeapBlockInfo* memmgr_heap_get_free_blocks_info(void) {
     BlockLink_t* pxBlock;
-    MemmgrHeapBlockInfo* blocks_info = NULL;
+    MemmgrHeapBlockInfo* info = NULL;
 
     vTaskSuspendAll();
 
@@ -256,42 +251,18 @@ void memmgr_heap_printf_free_blocks(void) {
     }
     blocks_info_sz++;
 
-    blocks_info = pvPortMalloc(blocks_info_sz * sizeof(MemmgrHeapBlockInfo));
+    info = malloc(sizeof(MemmgrHeapBlockInfo) + blocks_info_sz * sizeof(info->blocks[0]));
     size_t blocks_count = 0;
     pxBlock = &xStart;
     while((pxBlock->pxNextFreeBlock != NULL) && (blocks_count < blocks_info_sz)) {
-        blocks_info[blocks_count].addr = (size_t)pxBlock;
-        blocks_info[blocks_count].size = (size_t)pxBlock->xBlockSize;
+        info->blocks[blocks_count].addr = (size_t)pxBlock;
+        info->blocks[blocks_count].size = (size_t)pxBlock->xBlockSize;
         pxBlock = pxBlock->pxNextFreeBlock;
         blocks_count++;
     }
-
     xTaskResumeAll();
-
-    size_t total_free = 0;
-    size_t max_free = 0;
-    for(size_t i = 0; i < blocks_count; i++) {
-        size_t used_size = 0;
-        if(i < blocks_count - 1) {
-            used_size = blocks_info[i + 1].addr - (blocks_info[i].addr + blocks_info[i].size);
-        }
-        printf(
-            "0x%p\tFree: %lu \tUsed: %lu\r\n",
-            (void*)blocks_info[i].addr,
-            (uint32_t)blocks_info[i].size,
-            (uint32_t)used_size);
-
-        total_free += blocks_info[i].size;
-        if(blocks_info[i].size > max_free) {
-            max_free = blocks_info[i].size;
-        }
-    }
-    uint32_t fragmentation = total_free > 0 ? (100 - (max_free * 100 / total_free)) : 0;
-    printf(
-        "\r\nLargest free block: %lu\r\nFragmentation: %lu%%\r\n",
-        (uint32_t)max_free,
-        fragmentation);
-    vPortFree(blocks_info);
+    info->free_blocks = blocks_count;
+    return info;
 }
 
 #ifdef HEAP_PRINT_DEBUG

--- a/lib/furi/core/memmgr_heap.h
+++ b/lib/furi/core/memmgr_heap.h
@@ -14,6 +14,16 @@ extern "C" {
 
 #define MEMMGR_HEAP_UNKNOWN 0xFFFFFFFF
 
+/** Memmgr heap free blocks info structure
+ */
+typedef struct {
+    size_t free_blocks;
+    struct {
+        size_t addr;
+        size_t size;
+    } blocks[];
+} MemmgrHeapBlockInfo;
+
 /** Memmgr heap enable thread allocation tracking
  *
  * @param      thread_id  - thread id to track
@@ -40,10 +50,11 @@ size_t memmgr_heap_get_thread_memory(FuriThreadId thread_id);
  */
 size_t memmgr_heap_get_max_free_block(void);
 
-/** Print the address and size of all free blocks to stdout
+/** Gets the information about free heap blocks
+ *
+ * @return     pointer to allocated MemmgrHeapBlockInfo structure, should be freed by the caller
  */
-void memmgr_heap_printf_free_blocks(void);
-
+MemmgrHeapBlockInfo* memmgr_heap_get_free_blocks_info(void);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Replaced `memmgr_heap_printf_free_blocks` with `memmgr_heap_get_free_blocks_info`. Only returns MemmgrHeapBlockInfo struct without printing