### PR TITLE
FuriRecord: Atomic destroy, conditional opening

### DIFF
--- a/lib/furi/core/record.c
+++ b/lib/furi/core/record.c
@@ -91,7 +91,7 @@ static FuriRecordData* furi_record_data_get_or_create(const char* name) {
     furi_check(furi_record);
 
     FuriRecordData* record_data = furi_record_get(name);
-    if(record_data) {
+    if(!record_data) {
         record_data = furi_record_data_create(name);
     }
 

--- a/lib/furi/core/record.c
+++ b/lib/furi/core/record.c
@@ -15,7 +15,6 @@ typedef enum {
 
 typedef struct {
     FuriEventFlag* flags;
-    FuriThread* owner;
     void* data;
     uint16_t holders_count;
     uint16_t pending_count;
@@ -45,7 +44,6 @@ static void furi_record_erase(const char* name, FuriRecordData* record_data) {
 
 static void furi_record_reset(FuriRecordData* record_data) {
     furi_event_flag_clear(record_data->flags, FuriRecordFlagReady);
-    record_data->owner = NULL;
     record_data->data = NULL;
     record_data->pending_count = record_data->holders_count;
     record_data->holders_count = 0;
@@ -125,9 +123,8 @@ void furi_record_create(const char* name, void* data) {
 
     // Get record data and fill it
     FuriRecordData* record_data = furi_record_data_get_or_create(name);
-    furi_check(record_data->owner == NULL);
     furi_check(record_data->data == NULL);
-    record_data->owner = furi_thread_get_current();
+    furi_check(record_data->pending_count == 0);
     record_data->data = data;
     furi_event_flag_set(record_data->flags, FuriRecordFlagReady);
 
@@ -144,7 +141,6 @@ void furi_record_destroy(const char* name) {
 
     FuriRecordData* record_data = furi_record_get(name);
     furi_check(record_data);
-    furi_check(record_data->owner == furi_thread_get_current());
 
     if(record_data->holders_count == 0) {
         furi_record_erase(name, record_data);

--- a/lib/furi/core/record.c
+++ b/lib/furi/core/record.c
@@ -43,7 +43,7 @@ static void furi_record_erase(const char* name, FuriRecordData* record_data) {
 }
 
 static void furi_record_reset(FuriRecordData* record_data) {
-    furi_event_flag_clear(record_data->flags, FuriRecordFlagReady);
+    furi_event_flag_clear(record_data->flags, FuriRecordFlagReady | FuriRecordFlagReleased);
     record_data->data = NULL;
     record_data->pending_count = record_data->holders_count;
     record_data->holders_count = 0;
@@ -67,6 +67,26 @@ static void furi_record_data_wait_for_released(const FuriRecordData* record_data
         record_data->flags, FuriRecordFlagReleased, FuriFlagWaitAny, FuriWaitForever);
 
     furi_check(flags == FuriRecordFlagReleased);
+}
+
+static void furi_record_data_increment_count(FuriRecordData* record_data) {
+    furi_check(record_data->holders_count < FURI_RECORD_HOLDERS_MAX);
+    record_data->holders_count++;
+}
+
+static void furi_record_data_decrement_count(FuriRecordData* record_data) {
+    if(record_data->pending_count > 0) {
+        record_data->pending_count--;
+
+        if(record_data->pending_count == 0) {
+            furi_event_flag_set(record_data->flags, FuriRecordFlagReleased);
+        }
+
+    } else if(record_data->holders_count > 0) {
+        record_data->holders_count--;
+    } else {
+        furi_crash("Closed more times than opened");
+    }
 }
 
 static FuriRecordData* furi_record_data_create(const char* name) {
@@ -175,20 +195,24 @@ void* furi_record_open_ex(const char* name, uint32_t timeout) {
     furi_record_lock();
 
     FuriRecordData* record_data = furi_record_data_get_or_create(name);
-    furi_check(record_data->holders_count < FURI_RECORD_HOLDERS_MAX);
-    record_data->holders_count++;
+    furi_record_data_increment_count(record_data);
 
     furi_record_unlock();
 
-    if(!furi_record_data_wait_for_ready(record_data, timeout)) {
+    void* data_ptr = NULL;
+
+    if(furi_record_data_wait_for_ready(record_data, timeout)) {
+        data_ptr = record_data->data;
+
+    } else {
         furi_record_lock();
 
-        record_data->holders_count--;
+        furi_record_data_decrement_count(record_data);
 
         furi_record_unlock();
     }
 
-    return record_data->data;
+    return data_ptr;
 }
 
 void furi_record_close(const char* name) {
@@ -200,18 +224,7 @@ void furi_record_close(const char* name) {
     FuriRecordData* record_data = furi_record_get(name);
     furi_check(record_data);
 
-    if(record_data->pending_count > 0) {
-        record_data->pending_count--;
-
-        if(record_data->pending_count == 0) {
-            furi_event_flag_set(record_data->flags, FuriRecordFlagReleased);
-        }
-
-    } else if(record_data->holders_count > 0) {
-        record_data->holders_count--;
-    } else {
-        furi_crash("Closed more times than opened");
-    }
+    furi_record_data_decrement_count(record_data);
 
     furi_record_unlock();
 }

--- a/lib/furi/core/record.c
+++ b/lib/furi/core/record.c
@@ -44,6 +44,7 @@ static void furi_record_erase(const char* name, FuriRecordData* record_data) {
 
 static void furi_record_reset(FuriRecordData* record_data) {
     furi_event_flag_clear(record_data->flags, FuriRecordFlagReady | FuriRecordFlagReleased);
+
     record_data->data = NULL;
     record_data->pending_count = record_data->holders_count;
     record_data->holders_count = 0;
@@ -141,10 +142,10 @@ void furi_record_create(const char* name, void* data) {
 
     furi_record_lock();
 
-    // Get record data and fill it
     FuriRecordData* record_data = furi_record_data_get_or_create(name);
     furi_check(record_data->data == NULL);
     furi_check(record_data->pending_count == 0);
+
     record_data->data = data;
     furi_event_flag_set(record_data->flags, FuriRecordFlagReady);
 

--- a/lib/furi/core/record.c
+++ b/lib/furi/core/record.c
@@ -6,12 +6,19 @@
 #include <m-dict.h>
 #include <toolbox/m_cstr_dup.h>
 
-#define FURI_RECORD_FLAG_READY (0x1)
+#define FURI_RECORD_HOLDERS_MAX UINT16_MAX
+
+typedef enum {
+    FuriRecordFlagReady = 1UL << 0,
+    FuriRecordFlagReleased = 1UL << 1,
+} FuriRecordFlag;
 
 typedef struct {
     FuriEventFlag* flags;
+    FuriThread* owner;
     void* data;
-    size_t holders_count;
+    uint16_t holders_count;
+    uint16_t pending_count;
 } FuriRecordData;
 
 DICT_DEF2(FuriRecordDataDict, const char*, M_CSTR_DUP_OPLIST, FuriRecordData, M_POD_OPLIST)
@@ -27,7 +34,7 @@ static FuriRecordData* furi_record_get(const char* name) {
     return FuriRecordDataDict_get(furi_record->records, name);
 }
 
-static void furi_record_put(const char* name, FuriRecordData* record_data) {
+static void furi_record_put(const char* name, const FuriRecordData* record_data) {
     FuriRecordDataDict_set_at(furi_record->records, name, *record_data);
 }
 
@@ -36,23 +43,58 @@ static void furi_record_erase(const char* name, FuriRecordData* record_data) {
     FuriRecordDataDict_erase(furi_record->records, name);
 }
 
+static void furi_record_reset(FuriRecordData* record_data) {
+    furi_event_flag_clear(record_data->flags, FuriRecordFlagReady);
+    record_data->owner = NULL;
+    record_data->data = NULL;
+    record_data->pending_count = record_data->holders_count;
+    record_data->holders_count = 0;
+}
+
 void furi_record_init(void) {
     furi_record = malloc(sizeof(FuriRecord));
     furi_record->mutex = furi_mutex_alloc(FuriMutexTypeNormal);
     FuriRecordDataDict_init(furi_record->records);
 }
 
+static void furi_record_data_wait_for_ready(const FuriRecordData* record_data) {
+    const uint32_t flags = furi_event_flag_wait(
+        record_data->flags,
+        FuriRecordFlagReady,
+        FuriFlagWaitAny | FuriFlagNoClear,
+        FuriWaitForever);
+
+    furi_check(flags == FuriRecordFlagReady);
+}
+
+static void furi_record_data_wait_for_released(const FuriRecordData* record_data) {
+    const uint32_t flags = furi_event_flag_wait(
+        record_data->flags, FuriRecordFlagReleased, FuriFlagWaitAny, FuriWaitForever);
+
+    furi_check(flags == FuriRecordFlagReleased);
+}
+
+static FuriRecordData* furi_record_data_create(const char* name) {
+    const FuriRecordData new_record = {
+        .flags = furi_event_flag_alloc(),
+        .data = NULL,
+        .holders_count = 0,
+        .pending_count = 0,
+    };
+
+    furi_record_put(name, &new_record);
+
+    return furi_record_get(name);
+}
+
 static FuriRecordData* furi_record_data_get_or_create(const char* name) {
     furi_check(furi_record);
+
     FuriRecordData* record_data = furi_record_get(name);
-    if(!record_data) {
-        FuriRecordData new_record;
-        new_record.flags = furi_event_flag_alloc();
-        new_record.data = NULL;
-        new_record.holders_count = 0;
-        furi_record_put(name, &new_record);
-        record_data = furi_record_get(name);
+    if(record_data) {
+        record_data = furi_record_data_create(name);
     }
+
     return record_data;
 }
 
@@ -72,7 +114,7 @@ bool furi_record_exists(const char* name) {
 
     furi_record_lock();
     FuriRecordData* record_data = furi_record_get(name);
-    ret = record_data && (furi_event_flag_get(record_data->flags) & FURI_RECORD_FLAG_READY);
+    ret = record_data && (furi_event_flag_get(record_data->flags) & FuriRecordFlagReady);
     furi_record_unlock();
 
     return ret;
@@ -86,31 +128,47 @@ void furi_record_create(const char* name, void* data) {
 
     // Get record data and fill it
     FuriRecordData* record_data = furi_record_data_get_or_create(name);
+    furi_check(record_data->owner == NULL);
     furi_check(record_data->data == NULL);
+    record_data->owner = furi_thread_get_current();
     record_data->data = data;
-    furi_event_flag_set(record_data->flags, FURI_RECORD_FLAG_READY);
+    furi_event_flag_set(record_data->flags, FuriRecordFlagReady);
 
     furi_record_unlock();
 }
 
-bool furi_record_destroy(const char* name) {
+void furi_record_destroy(const char* name) {
     furi_check(furi_record);
     furi_check(name);
 
-    bool ret = false;
+    bool should_wait = false;
 
     furi_record_lock();
 
     FuriRecordData* record_data = furi_record_get(name);
     furi_check(record_data);
+    furi_check(record_data->owner == furi_thread_get_current());
+
     if(record_data->holders_count == 0) {
         furi_record_erase(name, record_data);
-        ret = true;
+    } else {
+        furi_record_reset(record_data);
+        should_wait = true;
     }
 
     furi_record_unlock();
 
-    return ret;
+    if(should_wait) {
+        furi_record_data_wait_for_released(record_data);
+
+        furi_record_lock();
+
+        if(record_data->holders_count == 0) {
+            furi_record_erase(name, record_data);
+        }
+
+        furi_record_unlock();
+    }
 }
 
 void* furi_record_open(const char* name) {
@@ -120,18 +178,12 @@ void* furi_record_open(const char* name) {
     furi_record_lock();
 
     FuriRecordData* record_data = furi_record_data_get_or_create(name);
+    furi_check(record_data->holders_count < FURI_RECORD_HOLDERS_MAX);
     record_data->holders_count++;
 
     furi_record_unlock();
 
-    // Wait for record to become ready
-    furi_check(
-        furi_event_flag_wait(
-            record_data->flags,
-            FURI_RECORD_FLAG_READY,
-            FuriFlagWaitAny | FuriFlagNoClear,
-            FuriWaitForever) == FURI_RECORD_FLAG_READY);
-
+    furi_record_data_wait_for_ready(record_data);
     return record_data->data;
 }
 
@@ -143,7 +195,19 @@ void furi_record_close(const char* name) {
 
     FuriRecordData* record_data = furi_record_get(name);
     furi_check(record_data);
-    record_data->holders_count--;
+
+    if(record_data->pending_count > 0) {
+        record_data->pending_count--;
+
+        if(record_data->pending_count == 0) {
+            furi_thread_flags_set(record_data->flags, FuriRecordFlagReleased);
+        }
+
+    } else if(record_data->holders_count > 0) {
+        record_data->holders_count--;
+    } else {
+        furi_crash("Closed more times than opened");
+    }
 
     furi_record_unlock();
 }

--- a/lib/furi/core/record.c
+++ b/lib/furi/core/record.c
@@ -57,14 +57,11 @@ void furi_record_init(void) {
     FuriRecordDataDict_init(furi_record->records);
 }
 
-static void furi_record_data_wait_for_ready(const FuriRecordData* record_data) {
+static bool furi_record_data_wait_for_ready(const FuriRecordData* record_data, uint32_t timeout) {
     const uint32_t flags = furi_event_flag_wait(
-        record_data->flags,
-        FuriRecordFlagReady,
-        FuriFlagWaitAny | FuriFlagNoClear,
-        FuriWaitForever);
+        record_data->flags, FuriRecordFlagReady, FuriFlagWaitAny | FuriFlagNoClear, timeout);
 
-    furi_check(flags == FuriRecordFlagReady);
+    return (flags == FuriRecordFlagReady);
 }
 
 static void furi_record_data_wait_for_released(const FuriRecordData* record_data) {
@@ -172,6 +169,10 @@ void furi_record_destroy(const char* name) {
 }
 
 void* furi_record_open(const char* name) {
+    return furi_record_open_ex(name, FuriWaitForever);
+}
+
+void* furi_record_open_ex(const char* name, uint32_t timeout) {
     furi_check(furi_record);
     furi_check(name);
 
@@ -183,7 +184,14 @@ void* furi_record_open(const char* name) {
 
     furi_record_unlock();
 
-    furi_record_data_wait_for_ready(record_data);
+    if(!furi_record_data_wait_for_ready(record_data, timeout)) {
+        furi_record_lock();
+
+        record_data->holders_count--;
+
+        furi_record_unlock();
+    }
+
     return record_data->data;
 }
 

--- a/lib/furi/core/record.c
+++ b/lib/furi/core/record.c
@@ -208,7 +208,7 @@ void furi_record_close(const char* name) {
         record_data->pending_count--;
 
         if(record_data->pending_count == 0) {
-            furi_thread_flags_set(record_data->flags, FuriRecordFlagReleased);
+            furi_event_flag_set(record_data->flags, FuriRecordFlagReleased);
         }
 
     } else if(record_data->holders_count > 0) {

--- a/lib/furi/core/record.h
+++ b/lib/furi/core/record.h
@@ -37,12 +37,14 @@ void furi_record_create(const char* name, void* data);
  *
  * @param      name  record name
  *
- * @return     true if successful, false if still have holders or thread is not
- *             owner.
+ * Blocks the calling thread until the record has been released by all its users.
+ * Threads calling `furi_record_open()` will be blocked until
+ * the record is created again via `furi_record_create()`.
+ *
  * @note       Thread safe. Create and destroy must be executed from the same
  *             thread.
  */
-bool furi_record_destroy(const char* name);
+void furi_record_destroy(const char* name);
 
 /** Open record
  *

--- a/lib/furi/core/record.h
+++ b/lib/furi/core/record.h
@@ -1,79 +1,155 @@
 /**
  * @file record.h
- * Furi: record API
+ * @brief Atomic reference-counted storage.
+ *
+ * The FuriRecord API provides a way of storing arbitrary data using a global
+ * key-value storage and a synchronisation mechanism for producers and consumers.
+ *
+ * All of the below functions are thread-safe, but care must be taken
+ * regarding the function call order (create/destroy, open/close).
+ *
+ * Data producers should use @ref furi_record_create to make their data available
+ * to consumers and @ref furi_record_create to revoke consumer access to it.
+ *
+ * ```C
+ * int producer_thread() {
+ *     MyData* data_ptr = my_data_alloc();
+ *
+ *     // Make data_ptr available under "my_data" record
+ *     furi_record_create("my_data", data_ptr);
+ *
+ *     // The record lifetime goes here
+ *
+ *     // Make data_ptr unavailable to consumers
+ *     // Note: this function will block until all consumers
+ *     // have called furi_record_close() (see below)
+ *     furi_record_destroy("my_data");
+ *
+ *     // It is now safe to actually free the data
+ *     my_data_free(data_ptr);
+ * }
+ * ```
+ *
+ * Data consumers should first use @ref furi_record_open or @ref furi_record_open_ex
+ * in order to gain access to the data required. After a record has been opened,
+ * it is guaranteed to be valid until a @ref furi_record_close call.
+ *
+ * ```C
+ * int consumer_thread() {
+ *     // Note: this function will block until
+ *     // the producer thread calls furi_record_create()
+ *     MyData* data_ptr = furi_record_open("my_data");
+ *
+ *     use_data(data_ptr);
+ *
+ *    // Release the data
+ *    furi_record_close("my_data");
+ *
+ *    // WRONG: data_ptr may no longer be valid at this point
+ *    use_data(data_ptr);
+ * }
+ *
+ * ```
  */
-
 #pragma once
 
 #include <stdint.h>
 #include <stdbool.h>
+
 #include "core_defines.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/** Initialize record storage For internal use only.
+/**
+ * @brief Initialize the record storage.
+ *
+ * @warning For internal use only. User code should NOT call this.
+ *
+ * This function is called during startup by the system initialisation procedure.
  */
 void furi_record_init(void);
 
-/** Check if record exists
+/**
+ * @brief Check if the record exists.
  *
- * @param      name  record name
- * @note       Thread safe. Create and destroy must be executed from the same
- *             thread.
+ * @param[in] name name of the record to check
+ *
+ * @returns @c true if the record exists, @c false otherwise
  */
 bool furi_record_exists(const char* name);
 
-/** Create record
+/**
+ * @brief Create a record with the given name and data.
  *
- * @param      name  record name
- * @param      data  data pointer
- * @note       Thread safe. Create and destroy must be executed from the same
- *             thread.
+ * After the record creation, pointer to @p data will be available
+ * to consumers via the @p name string key.
+ *
+ * @warning Record names MUST be unique at any point in time.
+ *
+ * @param[in] name name of the record to create
+ * @param[in] data pointer to an arbitrary value
  */
 void furi_record_create(const char* name, void* data);
 
-/** Destroy record
+/**
+ * @brief Destroy the record under the given name.
  *
- * @param      name  record name
+ * @pre The record MUST be created by @ref furi_record_create.
  *
- * Blocks the calling thread until the record has been released by all its users.
- * Threads calling `furi_record_open()` will be blocked until
+ * Blocks the calling thread until the record has been released by of all its users.
+ *
+ * Consumers calling `furi_record_open()` will be blocked until
  * the record is created again via `furi_record_create()`.
  *
- * @note       Thread safe. Create and destroy must be executed from the same
- *             thread.
+ * @warning It is only safe to destroy a record from the same thread
+ *          that created it using `furi_record_create()`
+ *
+ * @param[in] name name of the record to be destroyed
  */
 void furi_record_destroy(const char* name);
 
-/** Open record
+/**
+ * Open a record under the given name.
  *
- * @param      name  record name
+ * Blocks the calling thread indefinitely until the requested record becomes available.
  *
- * @return     pointer to the record
- * @note       Thread safe. Open and close must be executed from the same
- *             thread. Suspends caller thread till record is available
+ * The return value is guaranteed to be non-@c NULL. Additionally, it is guaranteed
+ * to remain valid (by contract) until a call to `furi_record_close()`.
+ *
+ * @note Consumer threads MUST always have a paired furi_record_close() call
+ *       once they are done working with the record data, unless they never exit
+ *       (e.g. service threads may not need to ever close a record)
+ *
+ * @param[in] name name of the record to be opened
+ *
+ * @returns pointer to the record data
  */
 FURI_RETURNS_NONNULL void* furi_record_open(const char* name);
 
-/** Open record or fail after a timeout
+/**
+ * @brief Open a record under a given name, extended version.
  *
- * @param      name  record name
- * @param      timeout timeout in ticks
+ * Same as @ref furi_record_open, but will fail if the requested record
+ * has not been made available by the producer within a specified timeout.
  *
- * @return     pointer to the record or @c NULL in case of failure
- * @note       Thread safe. Open and close must be executed from the same
- *             thread. Suspends caller thread till record is available or
- *             until the timeout has expired
+ * @param[in] name name of the record
+ * @param[in] timeout timeout to wait for the record, in ticks
+ *
+ * @return pointer to the record data or @c NULL if timeout occurred
  */
 void* furi_record_open_ex(const char* name, uint32_t timeout);
 
-/** Close record
+/**
+ * @brief Close a record under the given name.
  *
- * @param      name  record name
- * @note       Thread safe. Open and close must be executed from the same
- *             thread.
+ * @pre The record MUST be opened by @ref furi_record_open or @ref furi_record_open_ex.
+ *
+ * After a call to this function, the data pointer acquired via `furi_record_open()`
+ * MUST NOT be used.
+ *
+ * @param[in] name name of the record to be closed
  */
 void furi_record_close(const char* name);
 

--- a/lib/furi/core/record.h
+++ b/lib/furi/core/record.h
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <stdint.h>
 #include <stdbool.h>
 #include "core_defines.h"
 
@@ -55,6 +56,18 @@ void furi_record_destroy(const char* name);
  *             thread. Suspends caller thread till record is available
  */
 FURI_RETURNS_NONNULL void* furi_record_open(const char* name);
+
+/** Open record or fail after a timeout
+ *
+ * @param      name  record name
+ * @param      timeout timeout in ticks
+ *
+ * @return     pointer to the record or @c NULL in case of failure
+ * @note       Thread safe. Open and close must be executed from the same
+ *             thread. Suspends caller thread till record is available or
+ *             until the timeout has expired
+ */
+void* furi_record_open_ex(const char* name, uint32_t timeout);
 
 /** Close record
  *


### PR DESCRIPTION
# What's new

- Atomic `furi_record_destroy()`: block the calling thread until all previous consumers have called `furi_record_close()` and block all new calls to `furi_record_open()` until `furi_record_create()` is not called again by the producer
- Conditional record opening: call `furi_record_open_ex()` with a timeout in order to avoid infinite blockage