### PR TITLE
bit_lib: don't read past the buffer when the bit range fits one byte

### DIFF
--- a/lib/bit_lib/bit_lib.c
+++ b/lib/bit_lib/bit_lib.c
@@ -37,8 +37,10 @@ uint8_t bit_lib_get_bits(const uint8_t* data, size_t position, uint8_t length) {
     uint8_t shift = position % 8;
     if(shift == 0) {
         return data[position / 8] >> (8 - length);
+    } else if(shift + length <= 8) {
+        // Requested bits fit in the current byte, don't read the next one
+        return (uint8_t)(data[position / 8] << shift) >> (8 - length);
     } else {
-        // TODO FL-3534: fix read out of bounds
         uint8_t value = (data[position / 8] << (shift));
         value |= data[position / 8 + 1] >> (8 - shift);
         value = value >> (8 - length);


### PR DESCRIPTION
`bit_lib_get_bits()` reads `data[position / 8 + 1]` unconditionally on the non-byte-aligned path — the read-out-of-bounds the `// TODO FL-3534` comment right above it already calls out. When `shift + length <= 8` the requested bits sit entirely inside the current byte, so on a buffer that ends there this is a one-byte overrun for no reason: those next-byte bits get fully shifted out before the function returns.

Walk `bit_lib_get_bits(buf, 1, 1)` with a 1-byte `buf`: `shift = 1`, `length = 1`, `shift + length = 2`, but it still touches `buf[1]`. The next byte's contribution is `data[i+1] >> (8 - shift)` OR'd into the low `shift` bits, and the final `>> (8 - length)` drops everything below bit `8 - length`; since `8 - length >= shift` in this case, every bit that came from the next byte is shifted out. So the fix returns straight from the current byte when the range fits, and only reads the second byte when the bit range actually spans it.

Verification, all on host:
- Built the real (unmodified) `bit_lib.c` under ASan/UBSan and called `bit_lib_get_bits(malloc(1), 1, 1)` — clean `heap-buffer-overflow` at `bit_lib.c:43`, the exact line. The patched version returns the same value with no overflow.
- Swept all 192 `(shift, length, byte)` combinations, current code vs. patched: identical results, zero mismatches. Also varied the byte just past the range across several patterns for every `shift + length <= 8` case — the return value never depended on it, which is what makes dropping the read safe rather than just lucky.
- `bit_lib.c` compiles clean under `-Wall -Wextra -Werror` for cortex-m33.

The RP2350 EC firmware doesn't call `bit_lib` today, so this isn't biting flipperone-mcu-firmware right now; it matters for the bit-level protocol decoders in the other firmware that builds on these corelibs. Not run on hardware — it's straight-line integer code with no platform dependence, so the host tests cover it.
