### PR TITLE
EventLoop: fix use-after-free on FlagOnce auto-unsubscribe

### DIFF
--- a/lib/furi/core/event_loop.c
+++ b/lib/furi/core/event_loop.c
@@ -130,11 +130,14 @@ static inline FuriEventLoopProcessStatus
     furi_event_loop_process_event(FuriEventLoop* instance, FuriEventLoopItem* item) {
     FuriEventLoopProcessStatus status;
 
+    // Set current_item before the FlagOnce auto-unsubscribe so that
+    // furi_event_loop_unsubscribe() takes the free-later path instead of
+    // freeing the item that is about to be dereferenced and called through.
+    instance->current_item = item;
+
     if(item->event & FuriEventLoopEventFlagOnce) {
         furi_event_loop_unsubscribe(instance, item->object);
     }
-
-    instance->current_item = item;
 
     if(item->event & FuriEventLoopEventFlagEdge) {
         status = furi_event_loop_process_edge_event(item);
@@ -191,7 +194,7 @@ static void furi_event_loop_process_waiting_list(FuriEventLoop* instance) {
     } else if(status == FuriEventLoopProcessStatusIncomplete) {
         // Event processing incomplete, put item back in waiting list
         furi_event_loop_item_notify(item);
-    } else if(status == FuriEventLoopProcessStatusFreeLater) { //-V547
+    } else if(status == FuriEventLoopProcessStatusFreeLater) {
         // Unsubscribed from inside the callback, delete item
         furi_event_loop_item_free(item);
     } else {


### PR DESCRIPTION
`furi_event_loop_process_event()` runs the `FuriEventLoopEventFlagOnce` auto-unsubscribe before it sets `instance->current_item`. At that point `furi_event_loop_unsubscribe()` can't tell it's being called for the item that is about to be processed, so instead of `furi_event_loop_item_free_later()` it takes the `furi_event_loop_item_free()` path and frees the item on the spot. The function then uses the freed item four times: writes `instance->current_item = item`, reads `item->event`, calls `item->callback` through it, and reads `item->owner`.

Any subscription with `FlagOnce` set hits this the moment its event fires. flipperone-mcu-firmware runs into it today: the CLI `screen` command registers its pipe-broken callback with `FlagOnce`, so closing the CDC connection mid-`screen` lands exactly here (flipperdevices/flipperone-mcu-firmware#208 is the hard fault DrZlo13 traced).

The fix is to set `current_item` before the auto-unsubscribe. That routes it through the free-later path that already exists for unsubscribe-from-inside-callback: `item_free_later()` marks `owner = NULL` and keeps the memory alive, the callback runs on a live item, and the `owner == NULL` check at the bottom returns `FreeLater` so `furi_event_loop_process_waiting_list()` frees it exactly once. Explicit unsubscribe from inside a callback behaves the same as before.

Also dropped the `//-V547` suppression on the `FreeLater` branch: PVS was right that the branch was unreachable before (the immediate-free path never set `owner` to NULL), and with this change it's reachable, so the suppression is stale.

Verified by walking every path that touches `current_item`, `item_free`, and `item_free_later` (resubscribe-from-callback allocates a fresh item, double explicit unsubscribe still trips the same `furi_check` as before, waiting-list unlink happens pre-processing), and by building flipperone-mcu-firmware (a real consumer of this file, arm-none-eabi-gcc 14.2.1 + pico-sdk 2.2.0) against the patched submodule: clean build, no new warnings. Not run on hardware; the mcu-firmware side of #208 is getting a separate PR that also stops using `FlagOnce` for that callback.
