### PR TITLE
Enable building with picolibc

### DIFF
--- a/lib/furi/core/log.h
+++ b/lib/furi/core/log.h
@@ -98,7 +98,7 @@ void furi_log_puthex32(uint32_t data);
  * @param ... 
  */
 void furi_log_print_format(FuriLogLevel level, const char* tag, const char* format, ...)
-    _ATTRIBUTE((__format__(__printf__, 3, 4)));
+    __attribute__((__format__(__printf__, 3, 4)));
 
 /** Print log record
  * 
@@ -107,7 +107,7 @@ void furi_log_print_format(FuriLogLevel level, const char* tag, const char* form
  * @param ... 
  */
 void furi_log_print_raw_format(FuriLogLevel level, const char* format, ...)
-    _ATTRIBUTE((__format__(__printf__, 2, 3)));
+    __attribute__((__format__(__printf__, 2, 3)));
 
 /** Set log level
  *

--- a/lib/furi/core/memmgr.c
+++ b/lib/furi/core/memmgr.c
@@ -58,6 +58,10 @@ size_t memmgr_get_minimum_free_heap(void) {
     return xPortGetMinimumEverFreeHeapSize();
 }
 
+/* The _r allocator entry points exist only in newlib; picolibc has no struct _reent
+ * and routes everything through plain malloc()/free() above. */
+#ifndef __PICOLIBC__
+
 void* __wrap__malloc_r(struct _reent* r, size_t size) {
     UNUSED(r);
     return pvPortMalloc(size);
@@ -77,6 +81,8 @@ void* __wrap__realloc_r(struct _reent* r, void* ptr, size_t size) {
     UNUSED(r);
     return realloc(ptr, size);
 }
+
+#endif /* !__PICOLIBC__ */
 
 void* memmgr_alloc_from_pool(size_t size) {
     void* p = furi_hal_memory_alloc(size);

--- a/lib/furi/core/string.h
+++ b/lib/furi/core/string.h
@@ -63,7 +63,7 @@ FuriString* furi_string_alloc_set_str(const char cstr_source[]);
  * @return     pointer to the new instance of FuriString
  */
 FuriString* furi_string_alloc_printf(const char format[], ...)
-    _ATTRIBUTE((__format__(__printf__, 1, 2)));
+    __attribute__((__format__(__printf__, 1, 2)));
 
 /** Allocate new FuriString and printf to it.
  *
@@ -239,7 +239,7 @@ void furi_string_set_n(FuriString* string, const FuriString* source, size_t offs
  * @return     number of characters printed or negative value on error
  */
 int furi_string_printf(FuriString* string, const char format[], ...)
-    _ATTRIBUTE((__format__(__printf__, 2, 3)));
+    __attribute__((__format__(__printf__, 2, 3)));
 
 /** Format in the string the given printf format
  *
@@ -289,7 +289,7 @@ void furi_string_cat_str(FuriString* string_1, const char cstring_2[]);
  * @return     number of characters printed or negative value on error
  */
 int furi_string_cat_printf(FuriString* string, const char format[], ...)
-    _ATTRIBUTE((__format__(__printf__, 2, 3)));
+    __attribute__((__format__(__printf__, 2, 3)));
 
 /** Append to the string the formatted string of the given printf format.
  *

--- a/lib/print/printf_tiny.h
+++ b/lib/print/printf_tiny.h
@@ -55,7 +55,7 @@ void _putchar(char character);
  * \param format A string that specifies the format of the output
  * \return The number of characters that are written into the array, not counting the terminating null character
  */
-int printf_(const char* format, ...) _ATTRIBUTE((__format__(__printf__, 1, 2)));
+int printf_(const char* format, ...) __attribute__((__format__(__printf__, 1, 2)));
 
 /**
  * Tiny sprintf implementation
@@ -64,7 +64,7 @@ int printf_(const char* format, ...) _ATTRIBUTE((__format__(__printf__, 1, 2)));
  * \param format A string that specifies the format of the output
  * \return The number of characters that are WRITTEN into the buffer, not counting the terminating null character
  */
-int sprintf_(char* buffer, const char* format, ...) _ATTRIBUTE((__format__(__printf__, 2, 3)));
+int sprintf_(char* buffer, const char* format, ...) __attribute__((__format__(__printf__, 2, 3)));
 
 /**
  * Tiny snprintf/vsnprintf implementation
@@ -77,7 +77,7 @@ int sprintf_(char* buffer, const char* format, ...) _ATTRIBUTE((__format__(__pri
  *         is non-negative and less than count, the string has been completely written.
  */
 int snprintf_(char* buffer, size_t count, const char* format, ...)
-    _ATTRIBUTE((__format__(__printf__, 3, 4)));
+    __attribute__((__format__(__printf__, 3, 4)));
 int vsnprintf_(char* buffer, size_t count, const char* format, va_list va);
 
 /**
@@ -97,7 +97,7 @@ int vprintf_(const char* format, va_list va);
  * \return The number of characters that are sent to the output function, not counting the terminating null character
  */
 int fctprintf(void (*out)(char character, void* arg), void* arg, const char* format, ...)
-    _ATTRIBUTE((__format__(__printf__, 3, 4)));
+    __attribute__((__format__(__printf__, 3, 4)));
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Debian's distro-provided toolchain patches out newlib for picolibc, which currently fails to build our codebase here due to two newlib-specific things:

1. _ATTRIBUTE macro (translates cleanly into GCC's own __attribute__)
2. _r suffixed allocation functions for _reent specific use (which is absent from picolibc altogether, as it uses a different mechanism for thread local storage and doesn't have _reent)

Make the build work with picolibc when detected. No functional change for newlib based builds.