### PR TITLE
Record: retry destroy's release-wait until holders truly hit zero

### DIFF
--- a/lib/furi/core/record.c
+++ b/lib/furi/core/record.c
@@ -156,33 +156,22 @@ void furi_record_destroy(const char* name) {
     furi_check(furi_record);
     furi_check(name);
 
-    bool should_wait = false;
-
     furi_record_lock();
 
     FuriRecordData* record_data = furi_record_get(name);
     furi_check(record_data);
 
-    if(record_data->holders_count == 0) {
-        furi_record_erase(name, record_data);
-    } else {
+    while(record_data->holders_count != 0) {
         furi_record_reset(record_data);
-        should_wait = true;
-    }
-
-    furi_record_unlock();
-
-    if(should_wait) {
-        furi_record_data_wait_for_released(record_data);
-
-        furi_record_lock();
-
-        if(record_data->holders_count == 0) {
-            furi_record_erase(name, record_data);
-        }
 
         furi_record_unlock();
+        furi_record_data_wait_for_released(record_data);
+        furi_record_lock();
     }
+
+    furi_record_erase(name, record_data);
+
+    furi_record_unlock();
 }
 
 void* furi_record_open(const char* name) {


### PR DESCRIPTION
Fixes #41.

One thing up front about the base branch: this targets `bsb` because the bug only exists there. The racy wait pattern came in with #35, which merged to `bsb` only — `flipper_one`'s record.c still does the whole destroy inside one critical section, so there's nothing to fix on that side. I know fixes normally go to `flipper_one` first; happy to retarget or hold this if you'd rather stage it differently.

The race, short version: `destroy()` drops the lock to wait for existing holders to release. A `furi_record_open_ex()` from another thread can slip into that window and bump `holders_count` 0 -> 1. When the waiter wakes it checks `holders_count` once, sees it non-zero, and skips the erase entirely — returning as if the destroy worked. The entry and its `FuriEventFlag` leak, and the late opener is left waiting on a Ready flag nothing will ever set.

The fix is the loop sketched in the issue: after each wait, re-lock and either erase or reset-and-wait another round. `reset()` already clears both flags before each round, and the dict entry pointer stays valid across the loop (mlib's DICT_DEF2 is chained-bucket; resize re-links buckets but never moves an entry's node), so there's no new state and no lock-ordering change.

How it was verified: compiled the real, unmodified `record.c` from `bsb` HEAD against pthread-backed shims implementing the mutex/event-flag APIs, with a hook that fires the late opener deterministically the instant destroy drops the lock. Before the fix, destroy returns at ~41ms with the entry still in the dict (a second destroy call then completes fine, which proves the first one leaked it) and the late opener times out unserviced. After the fix, destroy blocks until the late opener drains and a 200-iteration randomized soak passes. ASan/UBSan clean throughout.

One behavior change to be aware of, not hidden in the diff: destroy now genuinely blocks until holders hit zero, which is what the record.h doc text says it does — but it means a late `furi_record_open()` caller with an infinite timeout, plus nothing ever recreating the record, would block destroy along with it. The old code "solved" that by leaking instead. If you'd rather bound the retry, say the word.

Caveat: the proof is host pthreads standing in for the RTOS mutex/event-flag semantics — no FreeRTOS scheduler involved, and no on-target test since no current caller destroys records with concurrent openers.
